### PR TITLE
daemon-reload on service task

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -52,3 +52,4 @@
     name: traefik
     state: started
     enabled: yes
+    daemon-reload: true


### PR DESCRIPTION
Required to avoid `FAILED! => {"changed": false, "msg": "Could not find the requested service traefik: host"}`