### PR TITLE
fix daemon-reload and start service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,26 +7,26 @@ services:
   - docker
 
 env:
-  - ANSIBLE_VERSION: 2.2
-  - ANSIBLE_VERSION: 2.3
-  - ANSIBLE_VERSION: 2.4
-  - ANSIBLE_VERSION: 2.5
-  - ANSIBLE_VERSION: 2.6
-  - ANSIBLE_VERSION: 2.7
+  - ANSIBLE_VERSION: v2.2
+  - ANSIBLE_VERSION: v2.3
+  - ANSIBLE_VERSION: v2.4.6.0-1
+  - ANSIBLE_VERSION: v2.5.12
+  - ANSIBLE_VERSION: v2.6.9
+  - ANSIBLE_VERSION: v2.7.3
 
 install:
   # Pull container
-  - sudo docker pull kitpages/docker-ansible:$ANSIBLE_VERSION
+  - sudo docker pull generik/ansible:$ANSIBLE_VERSION
 
   # Check ansible version
-  - sudo docker run -it --rm -v ${PWD}:/ansible -w /ansible kitpages/docker-ansible:$ANSIBLE_VERSION ansible-playbook --version
+  - sudo docker run -it --rm -v `pwd`:/ansible -w /ansible generik/ansible:$ANSIBLE_VERSION ansible-playbook --version
 
   # Create ansible.cfg with correct roles_path
   - printf '[defaults]\nroles_path=../' >ansible.cfg
 
 script:
   # Basic role syntax check
-  - sudo docker run -it --rm -v ${PWD}:/ansible-traefik -w /ansible-traefik kitpages/docker-ansible:$ANSIBLE_VERSION ansible-playbook tests/test.yml -i tests/inventory --syntax-check
+  - sudo docker run -it --rm -v ${PWD}:/ansible-traefik -w /ansible-traefik generik/ansible:$ANSIBLE_VERSION ansible-playbook tests/test.yml -i tests/inventory --syntax-check
 
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,12 @@ services:
   - docker
 
 env:
-  - ANSIBLE_VERSION: 1.9
-  - ANSIBLE_VERSION: 2.0
-  - ANSIBLE_VERSION: 2.1
   - ANSIBLE_VERSION: 2.2
+  - ANSIBLE_VERSION: 2.3
+  - ANSIBLE_VERSION: 2.4
+  - ANSIBLE_VERSION: 2.5
+  - ANSIBLE_VERSION: 2.6
+  - ANSIBLE_VERSION: 2.7
 
 install:
   # Pull container

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,7 +1,8 @@
 ---
 # handlers file for kibatic.traefik
-- name: Reload systemd daemon
-  command: systemctl daemon-reload
-
 - name: Restart traefik
-  command: systemctl restart traefik
+  systemd:
+    name: traefik
+    state: restarted
+    enabled: yes
+    daemon_reload: yes

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Ansible role to deploy traefik binary and systemd unit
   company: Kibatic
   license: MIT
-  min_ansible_version: 1.9
+  min_ansible_version: 2.2
   platforms:
     - name: Ubuntu
       versions:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,7 +8,6 @@
     group: root
     mode: 0644
   notify:
-    - Reload systemd daemon
     - Restart traefik
 
 - name: Ensure install & config directory exists
@@ -48,7 +47,8 @@
       dest: "{{ traefik_bin_path }}"
 
 - name: Ensure traefik service is enabled and running
-  service:
+  systemd:
     name: traefik
     state: started
     enabled: yes
+    daemon_reload: yes


### PR DESCRIPTION
there is an issue when service manually stopped on host and service file is updated, the start is not done properly.
same occurs if traefik is removed then reinstalled, service might not be available on when reaching start task.
Plus updated handler to use systemd module rather than command