### PR TITLE
Update traefik binary URL to v1.7.6

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # defaults file for kibatic.traefik
 traefik_install_dir: /usr/bin
-traefik_binary_url: https://github.com/containous/traefik/releases/download/v1.7.5/traefik_linux-amd64
+traefik_binary_url: https://github.com/containous/traefik/releases/download/v1.7.6/traefik_linux-amd64
 traefik_bin_path: "{{ traefik_install_dir }}/traefik"
 traefik_config_file: /etc/traefik.toml
 traefik_template: traefik.toml


### PR DESCRIPTION
Update the default `traefik_binary_url` to use version 1.7.6 of Traefik.