### PR TITLE
Install the newest traefik versions

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,17 +34,24 @@
     enabled: yes
   when: traefik_update == "yes"
 
+- name: check if traefik bin exists
+  stat:
+    path: "{{ traefik_bin_path }}"
+  register: traefik_bin
+
 - name: Download Traefik binary
-  get_url:
-    url: "{{ item.url }}"
+  unarchive:
+    src: "{{ item.url }}"
     dest: "{{ item.dest }}"
     owner: root
     group: root
     mode: 0755
-    force: "{{ traefik_update }}"
+    remote_src: yes
+    keep_newer: yes
   with_items:
     - url: "{{ traefik_binary_url }}"
-      dest: "{{ traefik_bin_path }}"
+      dest: "{{ traefik_install_dir }}"
+  when: traefik_bin.stat.exists == False
 
 - name: Ensure traefik service is enabled and running
   systemd:


### PR DESCRIPTION
Hey folks, I found out that current ansible role is not able to install latest Traefik versions, because they are not shipped just as binaries anymore.
From now they are shipped in `tar.gz` archives, so we need to load and extract them.

I know that this PR does not cover update scenario, but please tell me if this repo is alive and it's worth to improve my PR.
We can also support both way, for example have a fallback to and old method when someone tries to install a version that is shipped as a simple binary.