### PR TITLE
Fix configuration folder creation

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,6 +16,7 @@
     state: directory
   with_items:
     - "{{ traefik_install_dir }}"
+    - "{{ traefik_config_file | dirname }}"
 
 - name: Copy traefik config file
   template:


### PR DESCRIPTION
The role fails if the configuration folder doesn't exist.