### PR TITLE
Add support for 2.x download artefacts

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,0 +1,40 @@
+- name: Create temporary download directory
+  tempfile:
+    state: directory
+  register: download_dir
+
+- name: Download Traefik
+  get_url:
+    url: "{{ traefik_binary_url }}"
+    dest: "{{ download_dir.path }}"
+  register: traefik_download
+
+- name: Check type of downloaded asset
+  stat:
+    path: "{{ traefik_download.dest }}"
+  register: traefik_download_info
+
+- set_fact:
+    traefik_is_executable: "{{ traefik_download_info.stat.mimetype == 'application/x-executable' }}"
+
+- name: Unarchive traefik asset
+  unarchive:
+    src: "{{ traefik_download.dest }}"
+    dest: "{{ download_dir.path }}"
+    remote_src: yes
+  when: not traefik_is_executable
+
+- name: Ensure traefik service is stopped before traefik update
+  service:
+    name: traefik
+    state: stopped
+    enabled: yes
+
+- name: Copy traefik executable
+  copy:
+    src: "{{ traefik_download.dest if traefik_is_executable else download_dir.path + '/traefik' }}"
+    dest: "{{ traefik_bin_path }}"
+    owner: root
+    group: root
+    mode: 0755
+    remote_src: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,24 +28,14 @@
   notify:
     - Restart traefik
 
-- name: Ensure traefik service is stopped before traefik update
-  service:
-    name: traefik
-    state: stopped
-    enabled: yes
-  when: traefik_update | bool == True
+- name: Check if binary exists
+  stat:
+    path: "{{ traefik_bin_path }}"
+  register: traefik_bin
 
-- name: Download Traefik binary
-  get_url:
-    url: "{{ item.url }}"
-    dest: "{{ item.dest }}"
-    owner: root
-    group: root
-    mode: 0755
-    force: "{{ traefik_update | bool }}"
-  with_items:
-    - url: "{{ traefik_binary_url }}"
-      dest: "{{ traefik_bin_path }}"
+- include_tasks:
+    file: install.yml
+  when: traefik_update or not traefik_bin.stat.exists
 
 - name: Ensure traefik service is enabled and running
   systemd:


### PR DESCRIPTION
Since v2, traefik release artefacts are tar.gz files. This role relies on `get_url` only so it can not extract the executable from the archive.

Here I introduce some changes to support both v1 and v2 artefacts by detecting if the downloaded file is an executable or not. If it is not, we assume it is an archive and try to extract it.

I am aware that this is not the first MR to try to solve this, but this is how I solved it, now you can choose which one you prefer ;)